### PR TITLE
Add minimal tests for badge injector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,5 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install -U pytest
       - run: pytest -q
+        env:
+          PYTHONPATH: ${{ github.workspace }}

--- a/tests/test_badger.py
+++ b/tests/test_badger.py
@@ -1,0 +1,14 @@
+import pathlib
+import tempfile
+
+from badger import add_badges, BADGES
+
+def test_add_badges_inserts_badges(tmp_path: pathlib.Path):
+    readme = tmp_path / "README.md"
+    readme.write_text("Hello", encoding="utf-8")
+
+    add_badges(readme)
+
+    lines = readme.read_text(encoding="utf-8").splitlines()
+    assert lines[:len(BADGES)] == BADGES
+    assert "Hello" in lines


### PR DESCRIPTION
## Summary
- add a pytest that exercises add_badges so the workflow has coverage
- export PYTHONPATH during pytest to make badger importable

## Testing
- not run (rely on CI)